### PR TITLE
Fix auto-draft team membership error + add test mode (1 min picks)

### DIFF
--- a/src/app/actions/autoDraftActions.ts
+++ b/src/app/actions/autoDraftActions.ts
@@ -3,8 +3,8 @@
 
 import { createServerClient } from "@/lib/supabase";
 import { getAvailableCardsForDraft, type CardData } from "@/app/actions/cardActions";
-import { getTeamDraftPicks, addDraftPick } from "@/app/actions/draftActions";
-import { spendCubucksOnDraft, getTeamBalance } from "@/app/actions/cubucksActions";
+import { getTeamDraftPicks, addDraftPickInternal } from "@/app/actions/draftActions";
+import { spendCubucksOnDraftInternal, getTeamBalance } from "@/app/actions/cubucksActions";
 import { getDraftStatus } from "@/app/actions/draftOrderActions";
 
 // ============================================================================
@@ -713,8 +713,8 @@ export async function executeAutoDraft(
       return { success: false, error: `Insufficient Cubucks. Need ${cost}, have ${teamBalance?.cubucks_balance || 0}` };
     }
 
-    // Execute the draft: spend cubucks
-    const cubucksResult = await spendCubucksOnDraft(
+    // Execute the draft: spend cubucks (internal — no user session required)
+    const cubucksResult = await spendCubucksOnDraftInternal(
       teamId,
       card.card_id,
       card.card_name,
@@ -730,8 +730,8 @@ export async function executeAutoDraft(
     // Get current pick count for this team
     const { picks: existingPicks } = await getTeamDraftPicks(teamId);
 
-    // Add the draft pick
-    const pickResult = await addDraftPick({
+    // Add the draft pick (internal — no user session required)
+    const pickResult = await addDraftPickInternal({
       team_id: teamId,
       card_id: card.card_id,
       card_name: card.card_name,

--- a/src/app/actions/cubucksActions.ts
+++ b/src/app/actions/cubucksActions.ts
@@ -740,6 +740,44 @@ export async function spendCubucksOnDraft(
   }
 }
 
+/**
+ * Internal: Spend Cubucks on an auto-draft pick without user session check.
+ * Only for use by server-side auto-draft logic.
+ */
+export async function spendCubucksOnDraftInternal(
+  teamId: string,
+  cardId: string,
+  cardName: string,
+  cost: number,
+  cardPoolId?: string,
+  draftPickId?: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = await createServerClient();
+
+    // Call the stored procedure directly — no user session required
+    const { error } = await supabase.rpc("spend_cubucks_on_draft", {
+      p_team_id: teamId,
+      p_amount: cost,
+      p_card_id: cardId,
+      p_card_name: cardName,
+      p_draft_pick_id: draftPickId || null,
+      p_season_id: null,
+      p_card_pool_id: cardPoolId || null,
+    });
+
+    if (error) {
+      console.error("Error spending Cubucks (auto-draft):", error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error("Unexpected error spending Cubucks (auto-draft):", error);
+    return { success: false, error: String(error) };
+  }
+}
+
 // ============================================
 // SEASON ALLOCATION & CAP MANAGEMENT
 // ============================================

--- a/src/app/actions/draftActions.ts
+++ b/src/app/actions/draftActions.ts
@@ -223,6 +223,43 @@ export async function addDraftPick(
 }
 
 /**
+ * Internal: Add a draft pick without user session check.
+ * Only for use by server-side auto-draft logic.
+ */
+export async function addDraftPickInternal(
+  pick: DraftPick
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createClient();
+
+  try {
+    const { error } = await supabase.from("team_draft_picks").insert({
+      team_id: pick.team_id,
+      card_id: pick.card_id,
+      card_name: pick.card_name,
+      card_set: pick.card_set,
+      card_type: pick.card_type,
+      rarity: pick.rarity,
+      colors: pick.colors || [],
+      image_url: pick.image_url,
+      mana_cost: pick.mana_cost,
+      cmc: pick.cmc,
+      pick_number: pick.pick_number,
+      drafted_by: null, // auto-drafted — no user session
+    });
+
+    if (error) {
+      console.error("Error adding auto-draft pick:", error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error("Unexpected error adding auto-draft pick:", error);
+    return { success: false, error: "An unexpected error occurred" };
+  }
+}
+
+/**
  * Remove a card from team's draft picks
  */
 export async function removeDraftPick(

--- a/src/app/actions/draftSessionActions.ts
+++ b/src/app/actions/draftSessionActions.ts
@@ -121,8 +121,8 @@ export async function createDraftSession(config: {
     if (config.totalRounds < 1 || config.totalRounds > 999) {
       return { success: false, error: "Total rounds must be between 1 and 999" };
     }
-    if (config.hoursPerPick < 0.5 || config.hoursPerPick > 168) {
-      return { success: false, error: "Hours per pick must be between 0.5 and 168 (1 week)" };
+    if (config.hoursPerPick <= 0 || config.hoursPerPick > 168) {
+      return { success: false, error: "Hours per pick must be greater than 0 and at most 168 (1 week)" };
     }
 
     // Create the session


### PR DESCRIPTION
- addDraftPickInternal / spendCubucksOnDraftInternal: bypass user session checks so server-side auto-draft can insert picks without a logged-in user (fixes "you must be a member of this team" error on auto-pick)
- executeAutoDraft now calls the internal variants instead of the user-gated public functions
- Test Mode toggle in admin draft session panel sets hours_per_pick to 1 minute so auto-draft can be tested rapidly without waiting an hour
- Quick-select preset buttons (1 min test, 1h, 4h, 8h, 24h, 48h) in the create draft form
- Relaxed hours_per_pick validation floor from 0.5 to >0 in both the server action and admin UI