### PR TITLE
Fix test mode: immediately reset pick deadline when toggled

### DIFF
--- a/src/app/actions/draftSessionActions.ts
+++ b/src/app/actions/draftSessionActions.ts
@@ -258,6 +258,7 @@ export async function updateDraftSession(
     hoursPerPick?: number;
     startTime?: string;
     endTime?: string | null;
+    resetDeadline?: boolean; // if true, reset current_pick_deadline based on new hoursPerPick
   }
 ): Promise<{ success: boolean; error?: string }> {
   try {
@@ -273,6 +274,12 @@ export async function updateDraftSession(
     if (updates.hoursPerPick !== undefined) updateData.hours_per_pick = updates.hoursPerPick;
     if (updates.startTime !== undefined) updateData.start_time = updates.startTime;
     if (updates.endTime !== undefined) updateData.end_time = updates.endTime;
+
+    // Immediately recalculate the current pick deadline from now using the new hours value
+    if (updates.resetDeadline && updates.hoursPerPick !== undefined) {
+      const newDeadline = new Date(Date.now() + updates.hoursPerPick * 60 * 60 * 1000);
+      updateData.current_pick_deadline = newDeadline.toISOString();
+    }
 
     const { error } = await supabase
       .from("draft_sessions")

--- a/src/app/components/admin/DraftSessionManagement.tsx
+++ b/src/app/components/admin/DraftSessionManagement.tsx
@@ -263,7 +263,7 @@ export const DraftSessionManagement: React.FC = () => {
     if (!confirm(`Switch pick timer to ${label}?`)) return;
     setTestModeLoading(true);
     try {
-      const result = await updateDraftSession(sessionId, { hoursPerPick: newHours });
+      const result = await updateDraftSession(sessionId, { hoursPerPick: newHours, resetDeadline: true });
       if (result.success) {
         setMessage({ type: "success", text: `Pick timer set to ${label}` });
         loadData();


### PR DESCRIPTION
When enabling/disabling test mode the current_pick_deadline was not updated, so the countdown timer kept showing the old time. updateDraftSession now accepts a resetDeadline flag that recalculates current_pick_deadline from now using the new hoursPerPick value. handleToggleTestMode passes this flag so the timer reflects the change instantly.