### PR TITLE
Remove Discord username from Account Information card

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -128,14 +128,6 @@ export default function AccountPage() {
                 <CardContent>
                     <div className="space-y-3 text-sm">
                         <div className="flex justify-between py-2 border-b border-border">
-                            <span className="text-muted-foreground">Discord Username</span>
-                            <span className="font-medium">
-                                {user?.user_metadata?.username
-                                    ? `@${user.user_metadata.username}`
-                                    : user?.user_metadata?.full_name || "Unknown"}
-                            </span>
-                        </div>
-                        <div className="flex justify-between py-2 border-b border-border">
                             <span className="text-muted-foreground">Email</span>
                             <span className="font-medium">{user?.email}</span>
                         </div>


### PR DESCRIPTION
The Discord username field was showing the wrong value (full_name/global_name instead of the @handle). Per user request, removed the field entirely — the Account Information card now shows only Email, Member since, and Last sign in. The user's display name is already editable via the DisplayNameEditor component.