### PR TITLE
Filter hidden teams from signup team selection

### DIFF
--- a/src/app/actions/teamActions.ts
+++ b/src/app/actions/teamActions.ts
@@ -46,6 +46,7 @@ interface Team {
   name: string;
   emoji: string;
   motto: string;
+  is_hidden?: boolean;
   members?: TeamMember[];
 }
 

--- a/src/app/components/TeamSelection.tsx
+++ b/src/app/components/TeamSelection.tsx
@@ -9,6 +9,7 @@ interface Team {
   name: string;
   emoji: string;
   motto: string;
+  is_hidden?: boolean;
   members?: Array<{
     id: string;
     user_id: string;
@@ -39,7 +40,7 @@ export const TeamSelection: React.FC<TeamSelectionProps> = ({ userEmail, onTeamJ
     setLoading(true);
     try {
       const teamsData = await getTeamsWithMembers();
-      setTeams(teamsData);
+      setTeams(teamsData.filter((team) => !team.is_hidden));
     } catch (err) {
       console.error("Error loading teams:", err);
       setError("Failed to load teams");


### PR DESCRIPTION
## Summary
- Hidden teams are no longer shown to users during signup/onboarding team selection
- Team visibility now matches the public teams page (only teams where `is_hidden = false` are shown)
- Admin pages are unaffected and still see all teams including hidden ones

## Test plan
- [ ] Sign up / navigate to account page with no team assigned
- [ ] Verify only non-hidden teams appear in the team selection list
- [ ] Verify admin team management still shows all teams including hidden ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)