### PR TITLE
Add server-side draft timer (no browser required)

### DIFF
--- a/src/app/actions/autoDraftActions.ts
+++ b/src/app/actions/autoDraftActions.ts
@@ -2,7 +2,7 @@
 
 "use server";
 
-import { createServerClient } from "@/lib/supabase";
+import { createServerClient, type AnySupabaseClient } from "@/lib/supabase";
 
 import { getAvailableCardsForDraft, type CardData } from "@/app/actions/cardActions";
 
@@ -800,10 +800,11 @@ export async function clearTeamDraftQueue(
  * Cleans up team queues after a card has been drafted.
  */
 export async function conditionallyCleanupDraftQueues(
-  draftedCardId: string
+  draftedCardId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; cleaned: boolean; error?: string }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const duplicateSet = await getDuplicateCardIdSet();
     if (!duplicateSet.has(draftedCardId)) {
       const { error } = await supabase.from("team_draft_queue").delete().eq("card_id", draftedCardId);
@@ -828,7 +829,8 @@ export async function conditionallyCleanupDraftQueues(
  */
 export async function executeAutoDraft(
   teamId: string,
-  draftSessionId: string
+  draftSessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{
   success: boolean;
   pick?: { cardId: string; cardName: string; cost: number };
@@ -837,7 +839,7 @@ export async function executeAutoDraft(
   staleDeployment?: boolean;
 }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     // This is the fix: pass the draftSessionId to get a correctly scoped status
     const { status: draftStatus, error: statusError } = await getDraftStatus(draftSessionId);
     if (statusError || !draftStatus || !draftSessionId) {
@@ -851,7 +853,7 @@ export async function executeAutoDraft(
     const preview = await getAutoDraftPreview(teamId, draftSessionId);
     const card = preview.nextPick;
     if (!card) {
-      const { pick: skippedPick, error: skipError } = await addSkippedPick(teamId, pickNumber, draftSessionId);
+      const { pick: skippedPick, error: skipError } = await addSkippedPick(teamId, pickNumber, draftSessionId, adminClient);
       if (skipError) {
         return { success: false, source: "skipped", error: `Failed to record skipped pick: ${skipError}` };
       }
@@ -904,10 +906,10 @@ export async function executeAutoDraft(
       round_number: draftStatus.currentRound,
     });
     
-    await conditionallyCleanupDraftQueues(card.card_id);
-    
+    await conditionallyCleanupDraftQueues(card.card_id, adminClient);
+
     const { data: teamData } = await supabase.from('teams').select('name').eq('id', teamId).single();
-    
+
     const broadcastPayload = {
       ...newPick,
       team_name: teamData?.name || 'Unknown Team',

--- a/src/app/actions/draftActions.ts
+++ b/src/app/actions/draftActions.ts
@@ -4,6 +4,7 @@
 
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { AnySupabaseClient } from "@/lib/supabase";
 
 // Create a Supabase client with cookies support
 async function createClient() {
@@ -82,9 +83,10 @@ export interface DeckCard {
 export async function addSkippedPick(
   teamId: string,
   pickNumber: number,
-  draftSessionId: string
+  draftSessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; pick?: DraftPick; error?: string }> {
-  const supabase = await createClient();
+  const supabase = adminClient ?? await createClient();
   try {
     const skippedPickData = {
       team_id: teamId,

--- a/src/app/actions/draftSessionActions.ts
+++ b/src/app/actions/draftSessionActions.ts
@@ -2,7 +2,7 @@
 
 "use server";
 
-import { createServerClient } from "@/lib/supabase";
+import { createServerClient, type AnySupabaseClient } from "@/lib/supabase";
 import { getDraftStatus, type DraftStatus } from "@/app/actions/draftOrderActions";
 import { executeAutoDraft } from "@/app/actions/autoDraftActions";
 import { addSkippedPick, getTeamDraftPicks } from "@/app/actions/draftActions";
@@ -42,8 +42,8 @@ export interface DraftSessionInfo {
 // HELPERS
 // ============================================================================
 
-export async function resetSkipCounter(sessionId: string): Promise<void> {
-  const supabase = await createServerClient();
+export async function resetSkipCounter(sessionId: string, adminClient?: AnySupabaseClient): Promise<void> {
+  const supabase = adminClient ?? await createServerClient();
   try {
     await supabase
       .from("draft_sessions")
@@ -355,10 +355,11 @@ export async function deleteDraftSession(
 // ============================================================================
 
 async function completeDraftInternal(
-  sessionId: string
+  sessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const { error } = await supabase
       .from("draft_sessions")
       .update({
@@ -387,10 +388,11 @@ async function completeDraftInternal(
 }
 
 export async function activateDraft(
-  sessionId: string
+  sessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const { data: session, error: sessionError } = await supabase
       .from("draft_sessions")
       .select("*")
@@ -456,14 +458,15 @@ export async function activateDraft(
 }
 
 export async function advanceDraft(
-  sessionId: string
+  sessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{
   success: boolean;
   completed?: boolean;
   error?: string;
 }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const { data: session, error: sessionError } = await supabase
       .from("draft_sessions")
       .select("*")
@@ -501,7 +504,7 @@ export async function advanceDraft(
       teamBalances.every((t: { cubucks_balance: number }) => t.cubucks_balance <= 0);
 
     if (allTeamsReachedRounds || pastEndTime || allTeamsOutOfCubucks) {
-      await completeDraftInternal(session.id);
+      await completeDraftInternal(session.id, adminClient);
       return { success: true, completed: true };
     }
 
@@ -625,14 +628,14 @@ export async function completeDraft(
 // AUTO-DRAFT TIMER CHECK
 // ============================================================================
 
-export async function checkDraftTimer(): Promise<{
+export async function checkDraftTimer(adminClient?: AnySupabaseClient): Promise<{
   action: "none" | "activated" | "auto_drafted" | "completed" | "error";
   message?: string;
   error?: string;
   needsReload?: boolean;
 }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const now = new Date();
     const { data: session } = await supabase
       .from("draft_sessions")
@@ -644,7 +647,7 @@ export async function checkDraftTimer(): Promise<{
     if (!session) return { action: "none" };
 
     if (session.status === "scheduled" && new Date(session.start_time) <= now) {
-      const result = await activateDraft(session.id);
+      const result = await activateDraft(session.id, adminClient);
       return result.success
         ? { action: "activated", message: "Draft has been activated!" }
         : { action: "error", error: result.error };
@@ -690,10 +693,10 @@ export async function checkDraftTimer(): Promise<{
       return { action: "none" };
     }
 
-    const autoDraftResult = await executeAutoDraft(teamId, session.id);
+    const autoDraftResult = await executeAutoDraft(teamId, session.id, adminClient);
     if (autoDraftResult.success && autoDraftResult.source !== "skipped") {
-      await resetSkipCounter(session.id);
-      const advanceResult = await advanceDraft(session.id);
+      await resetSkipCounter(session.id, adminClient);
+      const advanceResult = await advanceDraft(session.id, adminClient);
       if (!advanceResult.success) {
         return { action: "error", error: `Auto-drafted but failed to advance: ${advanceResult.error}` };
       }
@@ -718,7 +721,7 @@ export async function checkDraftTimer(): Promise<{
       console.log(
         `Stall condition: ${newSkipCount} consecutive skips >= ${draftStatus.totalTeams} teams. Ending draft.`
       );
-      await completeDraftInternal(session.id);
+      await completeDraftInternal(session.id, adminClient);
       return {
         action: "completed",
         message: `The draft has ended automatically after ${newSkipCount} consecutive skipped picks.`,
@@ -732,13 +735,13 @@ export async function checkDraftTimer(): Promise<{
 
     if (!autoDraftResult.success) {
       const { picks: existingPicks } = await getTeamDraftPicks(teamId, session.id);
-      const skippedResult = await addSkippedPick(teamId, existingPicks.length + 1, session.id);
+      const skippedResult = await addSkippedPick(teamId, existingPicks.length + 1, session.id, adminClient);
       if (!skippedResult.success) {
         return { action: "error", error: `Auto-draft failed and could not log skipped pick: ${skippedResult.error}` };
       }
     }
 
-    const advanceResult = await advanceDraft(session.id);
+    const advanceResult = await advanceDraft(session.id, adminClient);
     if (!advanceResult.success) {
       return { action: "error", error: `Skip logged but failed to advance draft: ${advanceResult.error}` };
     }

--- a/src/app/api/cron/check-draft-timer/route.ts
+++ b/src/app/api/cron/check-draft-timer/route.ts
@@ -1,0 +1,30 @@
+// src/app/api/cron/check-draft-timer/route.ts
+// Manual trigger endpoint for the draft timer check.
+// The background timer in src/instrumentation.ts runs automatically every 60 seconds.
+// Call this endpoint to force an immediate check, e.g. for debugging.
+
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase";
+import { checkDraftTimer } from "@/app/actions/draftSessionActions";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  // Optional: protect with a secret header to prevent public abuse
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const adminClient = createAdminClient();
+    const result = await checkDraftTimer(adminClient);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    console.error("[Cron] check-draft-timer error:", error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,36 @@
+// src/instrumentation.ts
+// Runs once when the Next.js server starts (Node.js runtime only).
+// Starts a background timer that advances the draft without requiring any browser to be open.
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const { createAdminClient } = await import("@/lib/supabase");
+  const { checkDraftTimer } = await import("@/app/actions/draftSessionActions");
+
+  let adminClient: ReturnType<typeof createAdminClient>;
+  try {
+    adminClient = createAdminClient();
+  } catch {
+    // SUPABASE_SERVICE_ROLE_KEY not set — timer won't run server-side.
+    console.warn("[DraftTimer] SUPABASE_SERVICE_ROLE_KEY is not set. Background draft timer disabled.");
+    return;
+  }
+
+  const run = async () => {
+    try {
+      const result = await checkDraftTimer(adminClient);
+      if (result.action !== "none") {
+        console.log("[DraftTimer]", result.action, result.message ?? result.error ?? "");
+      }
+    } catch (err) {
+      console.error("[DraftTimer] Unexpected error:", err);
+    }
+  };
+
+  // Run immediately on startup, then every 60 seconds.
+  run();
+  setInterval(run, 60_000);
+
+  console.log("[DraftTimer] Background draft timer started (60s interval).");
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -27,6 +27,20 @@ export const getSupabaseClient = () => {
 // Export the singleton instance for client-side
 export const supabase = getSupabaseClient();
 
+// Admin client for server-to-server calls (cron jobs) — bypasses RLS via service role key
+export const createAdminClient = () => {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set. Required for server-side cron operations.");
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+};
+
+// Shared type for passing admin or server client through the call chain
+export type AnySupabaseClient = ReturnType<typeof createAdminClient>;
+
 // Export function for server-side usage with proper auth context
 export const createServerClient = async () => {
   const cookieStore = await cookies();


### PR DESCRIPTION
## Summary

- Adds `src/instrumentation.ts` which starts a background `setInterval` inside the Next.js server process, calling `checkDraftTimer()` every 60 seconds using a service-role admin Supabase client
- Threads an optional `adminClient?` parameter through the entire draft timer call chain (`checkDraftTimer` → `advanceDraft` / `activateDraft` / `executeAutoDraft` / `addSkippedPick` / etc.) so all DB writes bypass RLS when triggered server-side
- Adds `createAdminClient()` and `AnySupabaseClient` type to `src/lib/supabase.ts`
- Adds `/api/cron/check-draft-timer` route as a manual trigger endpoint for debugging

## Why

The draft was only advancing when a user had the page open (client-side `setInterval` in `DraftStatusWidget`). Now the timer runs inside the Next.js server process itself — no browser required.

## Setup required

Add `SUPABASE_SERVICE_ROLE_KEY` to your server environment (from Supabase → Settings → API). Without it, the background timer logs a warning and disables itself gracefully.

## Test plan

- [ ] Deploy and check server logs for `[DraftTimer] Background draft timer started (60s interval).`
- [ ] Let a pick timer expire with no browser open — confirm the draft advances automatically
- [ ] Hit `GET /api/cron/check-draft-timer` manually to force an immediate check

🤖 Generated with [Claude Code](https://claude.com/claude-code)