### PR TITLE
Fix background draft timer: cookies scope, on-clock team, and deadline updates

### DIFF
--- a/src/app/actions/autoDraftActions.ts
+++ b/src/app/actions/autoDraftActions.ts
@@ -56,8 +56,8 @@ function countDraftedColors(picks: Array<{ colors?: string[] }>): Record<string,
     return counts;
 }
 
-async function getTeamMemberCount(teamId: string): Promise<number> {
-    const supabase = await createServerClient();
+async function getTeamMemberCount(teamId: string, adminClient?: AnySupabaseClient): Promise<number> {
+    const supabase = adminClient ?? await createServerClient();
     const { count, error } = await supabase.from("team_members").select("*", { count: 'exact', head: true }).eq("team_id", teamId);
     if (error) {
         console.error("Error fetching team member count:", error);
@@ -126,13 +126,13 @@ async function executeConfirmedTeamPick(teamId: string, cardPoolId: string, draf
     return { success: true, pick: newPick };
 }
 
-export async function computeAutoDraftPick(teamId: string, draftSessionId: string): Promise<{ card: CardData | null; algorithmDetails: AlgorithmDetails | null; error?: string; }> {
+export async function computeAutoDraftPick(teamId: string, draftSessionId: string, adminClient?: AnySupabaseClient): Promise<{ card: CardData | null; algorithmDetails: AlgorithmDetails | null; error?: string; }> {
     try {
-        const { cards: availableCards, error: cardsError } = await getAvailableCardsForDraft();
+        const { cards: availableCards, error: cardsError } = await getAvailableCardsForDraft("default", adminClient);
         if (cardsError) return { card: null, algorithmDetails: null, error: cardsError };
         if (availableCards.length === 0) return { card: null, algorithmDetails: null, error: "No available cards in the pool" };
-        const { picks: teamPicks } = await getTeamDraftPicks(teamId, draftSessionId);
-        const { team: teamBalance } = await getTeamBalance(teamId);
+        const { picks: teamPicks } = await getTeamDraftPicks(teamId, draftSessionId, adminClient);
+        const { team: teamBalance } = await getTeamBalance(teamId, adminClient);
         const balance = teamBalance?.cubucks_balance ?? 0;
         const LAND_ELO_MODIFIER = 0.8;
         const AFFINITY_BONUS_PER_PICK = 0.1;
@@ -201,26 +201,26 @@ export async function computeAutoDraftPick(teamId: string, draftSessionId: strin
     }
 }
 
-export async function getAutoDraftPreview(teamId: string, draftSessionId: string): Promise<AutoDraftPreviewResult> {
+export async function getAutoDraftPreview(teamId: string, draftSessionId: string, adminClient?: AnySupabaseClient): Promise<AutoDraftPreviewResult> {
     try {
-        const supabase = await createServerClient();
+        const supabase = adminClient ?? await createServerClient();
         const { data: queueEntries, error: queueError } = await supabase.from("team_draft_queue").select("id, card_pool_id, card_id, card_name, position, pinned, votes").eq("team_id", teamId).order("position", { ascending: true });
         if (queueError) { console.error("Error fetching draft queue:", queueError); }
         const queueDepth = (queueEntries || []).length;
         if (queueEntries && queueEntries.length > 0) {
-            const { cards: availableCards } = await getAvailableCardsForDraft();
+            const { cards: availableCards } = await getAvailableCardsForDraft("default", adminClient);
             const availableInstanceIds = new Set(availableCards.map((c) => c.id));
             for (const entry of queueEntries) {
                 if (entry.card_pool_id && availableInstanceIds.has(entry.card_pool_id)) {
                     const card = availableCards.find((c) => c.id === entry.card_pool_id) || null;
-                    const memberCount = await getTeamMemberCount(teamId);
+                    const memberCount = await getTeamMemberCount(teamId, adminClient);
                     return { nextPick: card, source: "manual_queue", queueDepth, votes: entry.votes || [], voteThreshold: calculateVoteThreshold(memberCount), };
                 }
             }
         }
-        const { card, algorithmDetails, error } = await computeAutoDraftPick(teamId, draftSessionId);
+        const { card, algorithmDetails, error } = await computeAutoDraftPick(teamId, draftSessionId, adminClient);
         if (card) {
-            const { team: teamBalance } = await getTeamBalance(teamId);
+            const { team: teamBalance } = await getTeamBalance(teamId, adminClient);
             const balance = teamBalance?.cubucks_balance ?? 0;
             if ((card.cubucks_cost || 1) > balance) {
                 return { nextPick: null, source: "skipped", queueDepth, error: `Insufficient Cubucks. Need ${card.cubucks_cost || 1}, have ${balance}` };
@@ -374,7 +374,7 @@ export async function executeAutoDraft(
     }
     const { picks: existingPicks } = await getTeamDraftPicks(teamId, draftSessionId, supabase);
     const pickNumber = existingPicks.length + 1;
-    const preview = await getAutoDraftPreview(teamId, draftSessionId);
+    const preview = await getAutoDraftPreview(teamId, draftSessionId, supabase);
     const card = preview.nextPick;
     if (!card) {
       const { pick: skippedPick, error: skipError } = await addSkippedPick(teamId, pickNumber, draftSessionId, supabase);

--- a/src/app/actions/cardActions.ts
+++ b/src/app/actions/cardActions.ts
@@ -5,6 +5,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { invalidateDraftCache } from '@/lib/draftCache';
+import { type AnySupabaseClient } from "@/lib/supabase";
 
 async function createClient() {
   const cookieStore = await cookies();
@@ -108,8 +109,8 @@ export async function getCardPool(poolName: string = "default"): Promise<{ cards
   }
 }
 
-export async function getAvailableCardsForDraft(poolName: string = "default"): Promise<{ cards: CardData[]; error?: string }> {
-  const supabase = await createClient();
+export async function getAvailableCardsForDraft(poolName: string = "default", adminClient?: AnySupabaseClient): Promise<{ cards: CardData[]; error?: string }> {
+  const supabase = adminClient ?? await createClient();
   try {
     const { data: allCards, error: poolError } = await supabase.from("card_pools").select("*").eq("pool_name", poolName).eq('hidden', false).order("card_name", { ascending: true });
     if (poolError) {

--- a/src/app/actions/cubucksActions.ts
+++ b/src/app/actions/cubucksActions.ts
@@ -1,7 +1,7 @@
 // src/app/actions/cubucksActions.ts
 "use server";
 
-import { createServerClient } from "@/lib/supabase";
+import { createServerClient, type AnySupabaseClient } from "@/lib/supabase";
 
 // ============================================
 // TYPES
@@ -247,10 +247,11 @@ export async function getTeamBalances(): Promise<{
  * Get single team balance
  */
 export async function getTeamBalance(
-  teamId: string
+  teamId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ team: TeamBalance | null; error?: string }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
 
     const { data, error } = await supabase
       .from("teams")

--- a/src/app/actions/draftSessionActions.ts
+++ b/src/app/actions/draftSessionActions.ts
@@ -42,8 +42,8 @@ export interface DraftSessionWithStatus extends DraftSession {
  * Resets the consecutive skip counter for a draft session.
  * This should be called after a successful, non-skipped pick is made.
  */
-export async function resetSkipCounter(sessionId: string): Promise<void> {
-  const supabase = await createServerClient();
+export async function resetSkipCounter(sessionId: string, adminClient?: AnySupabaseClient): Promise<void> {
+  const supabase = adminClient ?? await createServerClient();
   try {
     await supabase
       .from("draft_sessions")
@@ -199,7 +199,7 @@ export async function getActiveDraftSession(): Promise<{
       return { session: null };
     }
 
-    const { status: draftStatus } = await getDraftStatus();
+    const { status: draftStatus } = await getDraftStatus(session.id, supabase);
     return {
       session: {
         ...session,
@@ -340,10 +340,11 @@ export async function deleteDraftSession(
  */
 
 export async function activateDraft(
-  sessionId: string
+  sessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const { data: session, error: sessionError } = await supabase
       .from("draft_sessions")
       .select("*")
@@ -357,7 +358,7 @@ export async function activateDraft(
       return { success: false, error: `Cannot activate a draft with status: ${session.status}` };
     }
 
-    const { status: draftStatus } = await getDraftStatus();
+    const { status: draftStatus } = await getDraftStatus(sessionId, supabase);
     if (!draftStatus) {
       return { success: false, error: "Could not determine draft status. Ensure draft order is set." };
     }
@@ -412,14 +413,14 @@ export async function activateDraft(
  * Checks if the draft is complete.
  * Resets the pick deadline and the consecutive skip counter.
  */
-export async function advanceDraft(): Promise<{
+export async function advanceDraft(adminClient?: AnySupabaseClient): Promise<{
   success: boolean;
   completed?: boolean;
    autoDrafted?: boolean;
   error?: string;
 }> {
   try {
-    const supabase = await createServerClient();
+    const supabase = adminClient ?? await createServerClient();
     const { data: session } = await supabase
       .from("draft_sessions")
       .select("*")
@@ -432,7 +433,7 @@ export async function advanceDraft(): Promise<{
       return { success: true }; // No active session, do nothing.
     }
 
-    const { status: draftStatus } = await getDraftStatus();
+    const { status: draftStatus } = await getDraftStatus(session.id, supabase);
     if (!draftStatus) {
       return { success: false, error: "Could not determine draft status" };
     }
@@ -453,7 +454,7 @@ export async function advanceDraft(): Promise<{
 
     if (allTeamsReachedRounds || pastEndTime || allTeamsOutOfCubucks) {
       // Draft is complete
-      await completeDraft(session.id);
+      await completeDraft(session.id, supabase);
       return { success: true, completed: true };
     }
 
@@ -548,13 +549,17 @@ export async function resumeDraft(
 }
 
 export async function completeDraft(
-  sessionId: string
+  sessionId: string,
+  adminClient?: AnySupabaseClient
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const supabase = await createServerClient();
-    const admin = await verifyAdmin(supabase);
-    if (!admin.authorized) {
-      return { success: false, error: admin.error };
+    const supabase = adminClient ?? await createServerClient();
+    // Skip auth check when called via service-role admin client (e.g. background timer)
+    if (!adminClient) {
+      const admin = await verifyAdmin(supabase as Awaited<ReturnType<typeof createServerClient>>);
+      if (!admin.authorized) {
+        return { success: false, error: admin.error };
+      }
     }
 
     const { error } = await supabase
@@ -604,37 +609,39 @@ export async function checkDraftTimer(adminClient?: AnySupabaseClient): Promise<
 
     const now = new Date();
     if (session.status === "scheduled" && new Date(session.start_time) <= now) {
-      const result = await activateDraft(session.id);
+      const result = await activateDraft(session.id, supabase);
       return result.success ? { action: "activated", message: "Draft has been activated!" } : { action: "error", error: result.error };
     }
-    
+
     if (session.status === "active" && session.current_pick_deadline && new Date(session.current_pick_deadline) <= now) {
-      const teamId = session.current_on_clock_team_id!;
+      // Always derive on-clock team from live pick counts, not from potentially stale column
+      const { status: draftStatus, error: statusError } = await getDraftStatus(session.id, supabase);
+      if (!draftStatus) {
+        return { action: "error", error: statusError || "Could not get draft status." };
+      }
+      const teamId = draftStatus.onTheClock.teamId;
+
       const autoDraftResult = await executeAutoDraft(teamId, session.id, supabase);
 
       // Case 1: A real card was successfully picked.
       if (autoDraftResult.success) {
-        await resetSkipCounter(session.id); // RESET THE COUNTER
-        const advanceResult = await advanceDraft();
+        await resetSkipCounter(session.id, supabase);
+        await advanceDraft(supabase);
         return {
           action: "auto_drafted",
           message: `Auto-drafted ${autoDraftResult.pick?.cardName || "a card"} for team ${teamId}.`
         };
       }
-      
-      // Case 2: The pick failed for any reason (no funds, no cards, etc.) and must be skipped.
+
+      // Case 2: The pick failed (no funds, no cards, etc.) — skip it.
       else {
         console.error(`Auto-draft failed for ${teamId}: ${autoDraftResult.error}. The pick will be skipped.`);
-        const { status: draftStatus } = await getDraftStatus();
-        if (!draftStatus) {
-            return { action: "error", error: "Could not get draft status to log skipped pick." };
-        }
-        
+
         const newSkipCount = (session.consecutive_skipped_picks || 0) + 1;
-        
+
         if (newSkipCount >= draftStatus.totalTeams) {
             console.log(`Stall condition met: ${newSkipCount} consecutive skips. Ending draft.`);
-            await completeDraft(session.id);
+            await completeDraft(session.id, supabase);
             return {
                 action: "completed",
                 message: `The draft has ended automatically after ${newSkipCount} consecutive skipped picks.`
@@ -642,12 +649,12 @@ export async function checkDraftTimer(adminClient?: AnySupabaseClient): Promise<
         }
 
         await supabase.from("draft_sessions").update({ consecutive_skipped_picks: newSkipCount }).eq("id", session.id);
-        const skippedResult = await addSkippedPick(teamId, draftStatus.totalPicks + 1, session.id);
+        const skippedResult = await addSkippedPick(teamId, draftStatus.totalPicks + 1, session.id, supabase);
         if (!skippedResult.success) {
             return { action: "error", error: `Auto-draft failed and could not log skipped pick: ${skippedResult.error}` };
         }
-        
-        const advanceResult = await advanceDraft();
+
+        const advanceResult = await advanceDraft(supabase);
         if (!advanceResult.success) {
             return { action: "error", error: `Auto-draft failed and draft could not be advanced: ${advanceResult.error}` };
         }


### PR DESCRIPTION
## Summary
- **Fixes `cookies` called outside request scope** — the instrumentation timer's entire call chain (advanceDraft, activateDraft, getAutoDraftPreview, getAvailableCardsForDraft, getTeamBalance, etc.) was internally calling `createServerClient()` which uses `next/headers cookies()`. Now threads the service-role `adminClient` all the way down so no cookies are needed in the background timer.
- **Fixes wrong team on the clock** — `activateDraft` and `advanceDraft` were calling `getDraftStatus()` without a session ID, causing pick counts to always be 0 and team #1 to always appear as on-the-clock. Both now pass the session ID for accurate pick count resolution. `checkDraftTimer` now derives `teamId` from live `getDraftStatus` instead of the potentially stale `current_on_clock_team_id` column.
- **Fixes `current_pick_deadline` not updating** — was a direct consequence of `advanceDraft` crashing before the update; fixed by the above.

## Test plan
- [ ] Start/resume a draft and verify the correct team is shown on the clock in the widget
- [ ] Let the timer expire and verify autodraft fires for the correct team
- [ ] Verify `current_pick_deadline` updates in the DB after each pick
- [ ] Verify no `cookies outside request scope` errors in server logs
- [ ] Verify skip counter increments and draft ends after all teams skip consecutively

🤖 Generated with [Claude Code](https://claude.com/claude-code)