### PR TITLE
Fix games table query and autodraft RPC placeholder params

### DIFF
--- a/src/app/actions/autoDraftActions.ts
+++ b/src/app/actions/autoDraftActions.ts
@@ -383,14 +383,40 @@ export async function executeAutoDraft(
       supabase.channel(`draft-updates-${draftSessionId}`).send({ type: 'broadcast', event: 'new_pick', payload: { ...skippedPick, team_name: teamData?.name || 'Unknown' } });
       return { success: true, source: "skipped", pick: { cardId: "skipped", cardName: "SKIPPED", cost: 0 } };
     }
-    const { data, error: rpcError } = await supabase.rpc("execute_atomic_draft_pick", { /* ...params... */ }).single();
+    const { data, error: rpcError } = await supabase.rpc("execute_atomic_draft_pick", {
+      p_team_id: teamId,
+      p_draft_session_id: draftSessionId,
+      p_card_pool_id: card.id,
+      p_card_id: card.card_id,
+      p_card_name: card.card_name,
+      p_card_set: card.card_set,
+      p_card_type: card.card_type,
+      p_rarity: card.rarity,
+      p_colors: card.colors,
+      p_image_url: card.image_url,
+      p_oldest_image_url: card.oldest_image_url,
+      p_mana_cost: card.mana_cost,
+      p_cmc: card.cmc,
+      p_pick_number: pickNumber,
+      p_cost: card.cubucks_cost || 1,
+      p_is_manual_pick: false,
+      p_user_id: null,
+    }).single();
     if (rpcError) {
       console.error("Atomic auto-draft failed:", rpcError);
       return { success: false, error: `Draft failed: ${rpcError.message}` };
     }
     const newPick = data as DraftPick;
     if (!newPick) return { success: false, error: "Draft pick could not be confirmed." };
-    await supabase.from("auto_draft_log").insert({ /* ...params... */ });
+    await supabase.from("auto_draft_log").insert({
+      team_id: teamId,
+      card_id: card.card_id,
+      card_name: card.card_name,
+      card_pool_id: card.id,
+      pick_source: preview.source === "manual_queue" ? "manual_queue" : "algorithm",
+      algorithm_details: preview.algorithmDetails ?? null,
+      round_number: pickNumber,
+    });
     await conditionallyCleanupDraftQueues(card.card_id, supabase);
     const { data: teamData } = await supabase.from('teams').select('name').eq('id', teamId).single();
     supabase.channel(`draft-updates-${draftSessionId}`).send({ type: 'broadcast', event: 'new_pick', payload: { ...newPick, team_name: teamData?.name || 'Unknown' } });

--- a/src/app/actions/homeActions.ts
+++ b/src/app/actions/homeActions.ts
@@ -288,27 +288,28 @@ export async function getRecentGames(limit: number = 5): Promise<{
 
   try {
     const { data, error } = await supabase
-      .from("games")
+      .from("matches")
       .select(`
         id,
-        team1_id,
-        team2_id,
-        team1_score,
-        team2_score,
-        winner_id,
-        played_at,
-        team1:teams!games_team1_id_fkey (
+        home_team_id,
+        away_team_id,
+        home_team_wins,
+        away_team_wins,
+        winner_team_id,
+        confirmed_at,
+        team1:teams!matches_home_team_id_fkey (
           id,
           name,
           emoji
         ),
-        team2:teams!games_team2_id_fkey (
+        team2:teams!matches_away_team_id_fkey (
           id,
           name,
           emoji
         )
       `)
-      .order("played_at", { ascending: false })
+      .eq("status", "completed")
+      .order("confirmed_at", { ascending: false })
       .limit(limit);
 
     if (error) {
@@ -316,21 +317,21 @@ export async function getRecentGames(limit: number = 5): Promise<{
       return { games: [], error: error.message };
     }
 
-    const games: RecentGame[] = (data || []).map((game) => {
-      const team1 = Array.isArray(game.team1) ? game.team1[0] : game.team1;
-      const team2 = Array.isArray(game.team2) ? game.team2[0] : game.team2;
+    const games: RecentGame[] = (data || []).map((match) => {
+      const team1 = Array.isArray(match.team1) ? match.team1[0] : match.team1;
+      const team2 = Array.isArray(match.team2) ? match.team2[0] : match.team2;
       return {
-        id: game.id,
-        team1_id: game.team1_id,
+        id: match.id,
+        team1_id: match.home_team_id,
         team1_name: team1?.name || "Unknown Team",
         team1_emoji: team1?.emoji || "❓",
-        team2_id: game.team2_id,
+        team2_id: match.away_team_id,
         team2_name: team2?.name || "Unknown Team",
         team2_emoji: team2?.emoji || "❓",
-        team1_score: game.team1_score,
-        team2_score: game.team2_score,
-        winner_id: game.winner_id,
-        played_at: game.played_at,
+        team1_score: match.home_team_wins,
+        team2_score: match.away_team_wins,
+        winner_id: match.winner_team_id,
+        played_at: match.confirmed_at,
       };
     });
 


### PR DESCRIPTION
## Summary
- **`getRecentGames` querying non-existent `games` table** — changed to query `matches` with the correct column names (`home_team_id`/`away_team_id`, `home_team_wins`/`away_team_wins`, `winner_team_id`, `confirmed_at`), filtered to `status = 'completed'`, with corrected FK join hints.
- **`executeAutoDraft` RPC call had empty placeholder params** — `execute_atomic_draft_pick` was being called with `{ /* ...params... */ }` so Supabase couldn't find the function signature. Filled in all parameters (`p_team_id`, `p_card_*`, `p_pick_number`, `p_is_manual_pick: false`, etc.). Also fixed the `auto_draft_log` insert which had the same placeholder issue.

## Test plan
- [ ] Home page loads without "Error fetching recent games" in server logs
- [ ] Recent completed matches appear in the home page game feed
- [ ] Auto-draft timer fires and successfully executes a pick (no RPC error in logs)
- [ ] `auto_draft_log` table receives an entry after an auto-draft fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)