### PR TITLE
Enhance CardPreview with headerOffset prop

### DIFF
--- a/src/app/components/CardPreview.tsx
+++ b/src/app/components/CardPreview.tsx
@@ -1,8 +1,7 @@
 // src/app/components/CardPreview.tsx
-
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useSettings } from "@/contexts/SettingsContext";
 import { getCardImageUrl } from "@/app/utils/cardUtils";
 
@@ -14,60 +13,86 @@ interface CardPreviewProps {
   };
   children: React.ReactNode;
   className?: string;
+  // Added a prop to handle the Replay Viewer header specifically
+  headerOffset?: number;
 }
 
 export const CardPreview: React.FC<CardPreviewProps> = ({
   card,
   children,
   className = "",
+  headerOffset = 55, // Default to your Replay Viewer header height
 }) => {
   const { useOldestArt } = useSettings();
   const [isHovering, setIsHovering] = useState(false);
   const [position, setPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  
   const containerRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
 
-  // Use the utility function to get the correct image URL
   const imageUrl = getCardImageUrl(card, useOldestArt);
 
-  useEffect(() => {
-    if (!isHovering || !containerRef.current) return;
+  // We use useLayoutEffect to calculate position AFTER the preview div is added to the DOM
+  // but BEFORE the browser repaints, preventing the "jump" effect.
+  useLayoutEffect(() => {
+    if (!isHovering || !containerRef.current || !previewRef.current) return;
+
     const updatePosition = () => {
       if (!containerRef.current || !previewRef.current) return;
 
       const rect = containerRef.current.getBoundingClientRect();
-      const previewWidth = 300;
-      const previewHeight = 420;
-      const padding = 16;
+      const previewRect = previewRef.current.getBoundingClientRect();
+      
+      const pWidth = previewRect.width;
+      const pHeight = previewRect.height;
+      const viewportW = window.innerWidth;
+      const viewportH = window.innerHeight;
+      const padding = 12;
 
+      // --- Horizontal Positioning ---
+      // Try placing it to the right first
       let x = rect.right + padding;
+
+      // If it overflows the right edge, try the left side
+      if (x + pWidth > viewportW - padding) {
+        x = rect.left - pWidth - padding;
+      }
+
+      // If it's still too far left (e.g. on mobile or narrow screen), center it
+      if (x < padding) {
+        x = (viewportW - pWidth) / 2;
+      }
+
+      // --- Vertical Positioning ---
+      // Align top of preview with top of card
       let y = rect.top;
 
-      if (x + previewWidth > window.innerWidth - padding) {
-        x = rect.left - previewWidth - padding;
+      // 1. Don't let it go off the bottom
+      if (y + pHeight > viewportH - padding) {
+        y = viewportH - pHeight - padding;
       }
-      if (x < padding) {
-        x = Math.max(padding, (rect.left + rect.right) / 2 - previewWidth / 2);
-      }
-      if (y + previewHeight > window.innerHeight - padding) {
-        y = window.innerHeight - previewHeight - padding;
-      }
-      if (y < padding) {
-        y = padding;
+
+      // 2. Don't let it hide under the top header (Replay Viewer Header)
+      if (y < headerOffset + padding) {
+        y = headerOffset + padding;
       }
 
       setPosition({ x, y });
     };
 
+    // Use a small delay to allow the image inside to potentially layout
+    // but the useLayoutEffect usually handles this.
     updatePosition();
-    window.addEventListener("scroll", updatePosition);
+
+    // Re-calculate if the user scrolls the game board or resizes the window
+    window.addEventListener("scroll", updatePosition, true);
     window.addEventListener("resize", updatePosition);
 
     return () => {
-      window.removeEventListener("scroll", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
       window.removeEventListener("resize", updatePosition);
     };
-  }, [isHovering]);
+  }, [isHovering, headerOffset]);
 
   return (
     <>
@@ -76,6 +101,7 @@ export const CardPreview: React.FC<CardPreviewProps> = ({
         className={className}
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
+        style={{ display: 'inline-block' }} // Ensure the ref hits the actual card boundaries
       >
         {children}
       </div>
@@ -83,18 +109,25 @@ export const CardPreview: React.FC<CardPreviewProps> = ({
       {isHovering && imageUrl && (
         <div
           ref={previewRef}
-          className="fixed z-50 pointer-events-none"
-          style={{ left: position.x, top: position.y }}
+          className="fixed pointer-events-none"
+          style={{ 
+            left: position.x, 
+            top: position.y,
+            // High z-index to clear Replay Controls (1500-1600)
+            zIndex: 9999,
+            // Optimization: hardware acceleration for smoother moving
+            willChange: 'transform', 
+          }}
         >
-          <div className="bg-black/90 rounded-xl p-2 shadow-2xl border border-gray-600">
+          <div className="bg-black/95 rounded-xl p-2 shadow-2xl border border-gray-600 backdrop-blur-sm">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={imageUrl}
               alt={card.card_name}
-              className="w-[300px] h-auto rounded-lg"
-              style={{ maxHeight: "420px", objectFit: "contain" }}
+              className="w-[280px] md:w-[320px] h-auto rounded-lg block"
+              style={{ objectFit: "contain" }}
             />
-            <div className="text-center text-white text-sm font-semibold mt-2 px-2 truncate">
+            <div className="text-center text-white text-sm font-bold mt-2 pb-1 px-2 truncate border-t border-white/10 pt-2">
               {card.card_name}
             </div>
           </div>


### PR DESCRIPTION
Added headerOffset prop to adjust the position of the preview based on the Replay Viewer header height. Updated positioning logic to use useLayoutEffect for smoother rendering.