### PR TITLE
Refactor service client initialization in adminActions

### DIFF
--- a/src/app/actions/adminActions.ts
+++ b/src/app/actions/adminActions.ts
@@ -231,7 +231,7 @@ if (pollEndDate < new Date()) {
 }
 // --- NEW FUNCTION TO FETCH TEST DECKLISTS ---
 export async function getTestDecklists(): Promise<{ p1_deck: string, p2_deck: string }> {
-    const supabase = createServiceRoleClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
+const supabase = createServiceRoleClient();
     try {
         const { data, error } = await supabase.from('test_decklists').select('player_slot, decklist');
         if (error) throw error;
@@ -248,7 +248,7 @@ export async function getTestDecklists(): Promise<{ p1_deck: string, p2_deck: st
 
 
 export async function getMatchReplay(matchId: string): Promise<MatchReplayData | null> {
-    const supabase = createServiceRoleClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
+const supabase = createServiceRoleClient();
     if (!matchId) {
         console.error("getMatchReplay called with invalid matchId");
         return null;
@@ -296,7 +296,7 @@ export async function getMatchReplay(matchId: string): Promise<MatchReplayData |
 
 
 export async function backfillOracleData(): Promise<{ success: boolean; updated: number; failed: number; errors: string[] }> {
-  const supabase = createServiceRoleClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
+const supabase = createServiceRoleClient();
   const errors: string[] = [];
   let updatedCount = 0;
   let failedCount = 0;
@@ -353,7 +353,7 @@ export async function backfillOracleData(): Promise<{ success: boolean; updated:
 }
 
 export async function validateAndCanonicalizeDeck(cardNames: string[]): Promise<{ valid: Map<string, string>; invalid: string[]; }> {
-  const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
+const supabase = createServiceRoleClient();
   const BASIC_LANDS = new Map<string, string>([["mountain", "Mountain"],["forest", "Forest"],["island", "Island"],["plains", "Plains"],["swamp", "Swamp"],]);
   const lowerCaseNames = [...new Set(cardNames.map(name => name.trim().toLowerCase()).filter(Boolean))];
   const validCanonicalMap = new Map<string, string>();


### PR DESCRIPTION
Updated getTestDecklists, getMatchReplay, backfillOracleData, and validateAndCanonicalizeDeck functions to use createServiceRoleClient without parameters.